### PR TITLE
Small fixes for `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-mkdir ~/.config/GIMP/3.0/themes/
+mkdir -p ~/.config/GIMP/3.0/themes/
 cp adw-gimp3 -Rv ~/.config/GIMP/3.0/themes/

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 mkdir ~/.config/GIMP/3.0/themes/
-cp cp adw-gimp3 -Rv ~/.config/GIMP/3.0/themes/
+cp adw-gimp3 -Rv ~/.config/GIMP/3.0/themes/


### PR DESCRIPTION
- Prevents script from failing if `~/.config/GIMP` directory doesn't already exist.
- Removes extra `cp` typo from command copying `adw-gimp3` directory.