### PR TITLE
feat: Configure flatpak in installer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.direnv/
+result/

--- a/README.md
+++ b/README.md
@@ -1,29 +1,90 @@
 # Adwaita Theme for GIMP 3: adw-gimp3
 
-_A complementary theme to adw-gtk3 for perfect GIMP styling_
+A complementary theme to `adw-gtk3` for perfect GIMP styling_
 
-### ⚠️ FLATPAK WARNING ⚠️
-Flatpak doesn’t apply your system themes by default. To enable them, follow these steps:
+![Theme preview](preview-dark.png)
+
+## Usage
+
+> [!NOTE]
+> If you have Nix installed, you can simply run:
+>
+> `nix run github:dp0sk/adw-gimp3`
+>
+> to launch a version of GIMP 3.0 with `adw-gimp3` built in.
+> or:
+>
+
+
+## Installation
+
+### Nix / NixOS
+
+Use the provided modules to use `adw-gimp3` in your configs:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    adw-gimp3.url = "github:dp0sk/adw-gimp3";
+  };
+  outputs = { nixpkgs, adw-gimp3, ... }@inputs: {
+    # Install system-wide on a NixOS system:
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      modules = [adw-gimp3.nixosModules.default];
+    };
+
+    # Install in your user home environment:
+    homeConfigurations.my-home = home-manager.lib.homeConfiguration {
+      modules = [adw-gimp3.homeManagerModules.default];
+    };
+  };
+}
+```
+
+
+or install GIMP 3.0 with `adw-gimp3` to a profile:
+
+```bash
+
+nix profile install github:dp0sk/adw-gimp3`
+
+````
+
+### Manual Installation
+
+> [!NOTE]
+> This theme depends on [`adw-gtk3`](https://github.com/lassekongo83/adw-gtk3) installation.
+> Follow the instructions there before proceeding with `adw-gimp3` installation.
+
+### Install `adw-gtk3`
+
+`install.sh` will handle the flatpak configuration automatically.
+
+1. Install the [adw-gtk3](https://github.com/lassekongo83/adw-gtk3) theme first.
+2. Enable the `adw-gtk3` theme via one of the following:
+  - GNOME Tweaks
+  - [Refine](https://flathub.org/apps/page.tesk.Refine)
+  <!-- - TODO: fix -->
+  <!-- `gsettings set org.gnome.desktop gtk-theem adw-gtk3` -->
+
+#### Configuring flatpak
+
+Manually:
 
 1. Install [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal)
 2. Navigate to `All applications (global) → Filesystem → Other files`
 3. Add these lines: 	
-   - `~/.config/gtk-3.0`
-   - `~/.config/gtk-3.0:ro`
-   - `~/.config/gtk-4.0`
-   - `~/.config/gtk-4.0:ro`
-   - `~/.themes`
-   - `~/.themes:ro`
    - `xdg-config/gtk-3.0:ro`
-   - `xdg-config/gtk-3.0`
    - `xdg-config/gtk-4.0:ro`
-   - `xdg-config/gtk-4.0`
 4. Now all your flatpak apps will be themed!
 
-### Installation
 
-1. Install the [adw-gtk3](https://github.com/lassekongo83/adw-gtk3) theme first and enable it in Gnome Tweaks or [Refine](https://flathub.org/apps/page.tesk.Refine)
-2. Download the adw-gimp3 repository
+
+> [!WARNING]
+> Flatpak doesn’t apply your system themes by default. To enable them, follow these steps:
+
+2. Download the `adw-gimp3` repository
 3. Either:
    - Run `install.sh`, or
    - Manually copy the `adw-gimp3` folder to `~/.config/GIMP/3.0/themes/`
@@ -34,9 +95,8 @@ Launch GIMP and navigate to:
 6. Done!
 
 ### Notes
-- This theme depends on adw-gtk3 installation
+
+- This theme depends on `adw-gtk3` installation
 - Currently only dark theme is supported (Light theme will be added)
 - Windows and macOS support is planned (Will be supported in future updates)
 
-### Screenshot
-![Theme preview](preview-dark.png)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Adwaita Theme for GIMP 3: adw-gimp3
 
-A complementary theme to `adw-gtk3` for perfect GIMP styling_
+A complementary theme to `adw-gtk3` for perfect GIMP styling.
+
+> [!NOTE]
+> Currently, only dark theme is officially supported (Light theme will be added later)
 
 ![Theme preview](preview-dark.png)
+
 
 ## Usage
 
@@ -12,23 +16,36 @@ A complementary theme to `adw-gtk3` for perfect GIMP styling_
 > `nix run github:dp0sk/adw-gimp3`
 >
 > to launch a version of GIMP 3.0 with `adw-gimp3` built in.
-> or:
->
 
 
 ## Installation
 
+> [!NOTE]
+> This theme depends on [`adw-gtk3`](https://github.com/lassekongo83/adw-gtk3) installation,
+> for non-NixOS systems.
+> Follow the instructions there before proceeding with `adw-gimp3` installation.
+
 ### Nix / NixOS
 
-Use the provided modules to use `adw-gimp3` in your configs:
+[NixOS](https://nixos.org),
+[nix-darwin](https://github.com/LnL7/nix-darwin), &
+[home-manager](https://github.com/nix-community/home-manager)
+users can use the provided modules to install GIMP pre-loaded with the `adw-gimp3` theme in your environment configs:
 
 ```nix
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nix-darwin.url = "github:LnL7/nix-darwin/nix-darwin-24.11"
+    home-manager.url = "github:nix-community/home-manager";
     adw-gimp3.url = "github:dp0sk/adw-gimp3";
   };
-  outputs = { nixpkgs, adw-gimp3, ... }@inputs: {
+  outputs = inputs@{ nixpkgs, nix-darwin, adw-gimp3, ... }: {
+    # Install system-wide on a nix-darwin system:
+    darwinConfigurations."Johns-Macbook" = nix-darwin.lib.darwinSystem {
+      modules = [adw-gimp3.darwinModules.default];
+    };
+
     # Install system-wide on a NixOS system:
     nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
       modules = [adw-gimp3.nixosModules.default];
@@ -42,35 +59,55 @@ Use the provided modules to use `adw-gimp3` in your configs:
 }
 ```
 
-
 or install GIMP 3.0 with `adw-gimp3` to a profile:
 
 ```bash
-
 nix profile install github:dp0sk/adw-gimp3`
-
-````
+```
 
 ### Manual Installation
 
-> [!NOTE]
-> This theme depends on [`adw-gtk3`](https://github.com/lassekongo83/adw-gtk3) installation.
-> Follow the instructions there before proceeding with `adw-gimp3` installation.
-
-### Install `adw-gtk3`
-
-`install.sh` will handle the flatpak configuration automatically.
+#### adw-gtk3
 
 1. Install the [adw-gtk3](https://github.com/lassekongo83/adw-gtk3) theme first.
+
 2. Enable the `adw-gtk3` theme via one of the following:
+
   - GNOME Tweaks
   - [Refine](https://flathub.org/apps/page.tesk.Refine)
-  <!-- - TODO: fix -->
-  <!-- `gsettings set org.gnome.desktop gtk-theem adw-gtk3` -->
+  - Run: `gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3'`
+
+
+#### adw-gimp3
+
+1. Download the `adw-gimp3` repository
+
+    ```bash
+    git clone https://github.com/dp0sk/adw-gimp3
+    cd adw-gimp3
+    ```
+
+2. Install the theme to your config directory by either running the installation script (`install.sh`) **OR** manually copying the `adw-gimp3` folder to `~/.config/GIMP/3.0/themes/`:
+
+    ```bash
+    mkdir -p ~/.config/GIMP/3.0/themes
+    cp -r adw-gimp3 ~/.config/GIMP/3.0/themes
+    ```
+
+3. Launch GIMP
+4. Navigate to `Edit → Preferences → Theme`
+5. Select the `adw-gimp3` theme.
+6. *(Optional)* For better integration, navigate to: `Edit → Preferences → Image Windows`
+7. *(Optional)* Enable `"Merge menu and title bar"`
+8. Done!
 
 #### Configuring flatpak
 
-Manually:
+> [!NOTE]
+> `install.sh` will handle the flatpak configuration automatically.
+
+> [!WARNING]
+> Flatpak doesn’t apply your system themes by default. To enable them, follow these steps:
 
 1. Install [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal)
 2. Navigate to `All applications (global) → Filesystem → Other files`
@@ -79,24 +116,7 @@ Manually:
    - `xdg-config/gtk-4.0:ro`
 4. Now all your flatpak apps will be themed!
 
+## Notes
 
-
-> [!WARNING]
-> Flatpak doesn’t apply your system themes by default. To enable them, follow these steps:
-
-2. Download the `adw-gimp3` repository
-3. Either:
-   - Run `install.sh`, or
-   - Manually copy the `adw-gimp3` folder to `~/.config/GIMP/3.0/themes/`
-Launch GIMP and navigate to:
-   `Edit → Preferences → Theme` → Select "adw-gimp3"
-5. *(Optional)* For better integration:
-   `Edit → Preferences → Image Windows` → Enable "Merge menu and title bar"
-6. Done!
-
-### Notes
-
-- This theme depends on `adw-gtk3` installation
-- Currently only dark theme is supported (Light theme will be added)
-- Windows and macOS support is planned (Will be supported in future updates)
+- Windows & macOS support is planned (Will be supported in future updates)
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742290322,
+        "narHash": "sha256-k9JklbgcYhEzNgwNMP+dDF7VgYRokmAYvnqyNbBmip0=",
+        "owner": "jtojnar",
+        "repo": "nixpkgs",
+        "rev": "c88e4e90048eaeaadc0caec090fed4ce5cc62240",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jtojnar",
+        "ref": "gimp-meson",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "wrapper-manager": "wrapper-manager"
+      }
+    },
+    "wrapper-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1724503599,
+        "narHash": "sha256-WVhNq3QjnG/2mi772CkTxZCQcomKV5S03TbQKwe1Kj4=",
+        "owner": "viperML",
+        "repo": "wrapper-manager",
+        "rev": "c936f9203217e654a6074d206505c16432edbc70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "viperML",
+        "repo": "wrapper-manager",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,16 @@
             '';
           };
         };
+        devShells.default = pkgs.mkShell {
+          name = "adw-gimp3";
+          packages = with pkgs; [
+            adw-gtk3
+          ];
+          inputsFrom = with pkgs; [
+            gimp-with-plugins
+            self'.packages.gimp
+          ];
+        };
         packages.default = self'.packages.gimp;
         packages.adw-gimp3 = pkgs.stdenv.mkDerivation {
           name = "adw-gimp3";
@@ -73,6 +83,7 @@
                 gimprc = pkgs.writeText "gimprc" ''
                   (theme-path "''${gimp_dir}/themes:''${gimp_data_dir}/themes:${unwrapped.outPath}/share/gimp/3.0/themes")
                   (theme "Adwaita")
+                  (custom-title-bar yes)
                 '';
               in {
                 basePackage = unwrapped;
@@ -81,6 +92,12 @@
             }
           ];
         };
+      };
+      flake.darwinModules.default = {pkgs, ...}: {
+        environment.systemPackages = with pkgs; [
+          self'.packages.gimp
+          adw-gtk3
+        ];
       };
       flake.nixosModules.default = {pkgs, ...}: {
         environment.systemPackages = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "Flake for adw-gimp3 theme.";
+  inputs = {
+    # Temporarily use nixpkgs fork until GIMP 3.0 is merged upstream
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:jtojnar/nixpkgs/gimp-meson";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    wrapper-manager = {
+      url = "github:viperML/wrapper-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = inputs @ {self, ...}:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      perSystem = {
+        self',
+        pkgs,
+        ...
+      }: {
+        apps.default = self'.apps.gimp;
+        apps.gimp = {
+          meta.description = "GIMP 3.0 with Adwaita theme";
+          type = "app";
+          program = "${self'.packages.gimp}/bin/gimp";
+        };
+        apps.set-theme = {
+          meta.description = "GIMP 3.0 with Adwaita theme";
+          type = "app";
+          program = pkgs.writeShellApplication {
+            name = "set-gtk3-theme";
+            runtimeInputs = with pkgs; [adw-gtk3];
+            text = ''
+              scheme="'$1'"
+              gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3' && \
+              if [[ $# -gt 0 ]]; then
+                gsettings set org.gnome.desktop.interface color-scheme $scheme
+              fi
+            '';
+          };
+        };
+        packages.default = self'.packages.gimp;
+        packages.adw-gimp3 = pkgs.stdenv.mkDerivation {
+          name = "adw-gimp3";
+          version = "2025-03-25";
+          src = ./.;
+          installPhase = ''
+            mkdir -p $out
+            cp -Rv $src/adw-gimp3/* $out
+          '';
+        };
+        packages.gimp = inputs.wrapper-manager.lib.build {
+          inherit pkgs;
+          modules = [
+            {
+              wrappers.adw-gimp3 = let
+                unwrapped = pkgs.symlinkJoin {
+                  name = "gimp";
+                  paths = [
+                    pkgs.adw-gtk3
+                    pkgs.gimp-with-plugins
+                    (pkgs.stdenv.mkDerivation {
+                      name = "adw-gimp3";
+                      version = "2025-03-25";
+                      src = ./.;
+                      installPhase = ''
+                        mkdir -p $out/share/gimp/3.0/themes/Adwaita
+                        cp -Rv $src/adw-gimp3/* $out/share/gimp/3.0/themes/Adwaita
+                      '';
+                    })
+                  ];
+                };
+                gimprc = pkgs.writeText "gimprc" ''
+                  (theme-path "''${gimp_dir}/themes:''${gimp_data_dir}/themes:${unwrapped.outPath}/share/gimp/3.0/themes")
+                  (theme "Adwaita")
+                '';
+              in {
+                basePackage = unwrapped;
+                prependFlags = ["--system-gimprc" gimprc];
+              };
+            }
+          ];
+        };
+      };
+      flake.nixosModules.default = {pkgs, ...}: {
+        environment.systemPackages = with pkgs; [
+          self'.packages.gimp
+          adw-gtk3
+        ];
+      };
+      flake.homeManagerModules.default = {pkgs, ...}: {
+        gtk.theme = {
+          package = pkgs.adw-gtk3;
+          name = "adw-gtk3";
+        };
+        home.packages = [self.packages.${pkgs.system}.gimp];
+      };
+    };
+}

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,40 @@
 #!/usr/bin/env bash
 
-mkdir -p ~/.config/GIMP/3.0/themes/
-cp adw-gimp3 -Rv ~/.config/GIMP/3.0/themes/
+echo 'Installing adw-gimp3...'
+
+if command -v gimp >/dev/null; then
+  echo '[system] copying theme...'
+  mkdir -p ~/.config/GIMP/3.0/themes
+  cp -Rv adw-gimp3 ~/.config/GIMP/3.0/themes/
+
+  if command -v flatpak >/dev/null; then
+    if [[ -d "$HOME/.var/app/org.gimp.GIMP" ]]; then
+      echo -n '[flatpak-user:org.gimp.GIMP] creating override...'
+      flatpak override --user --filesystem=xdg-config/GIMP/3.0/themes/adw-gimp3:ro org.gimp.GIMP && echo 'done.'
+    fi
+
+    if [[ -d "$HOME/.var/app/org.gimp.GIMP.Nightly" ]]; then
+      echo -n '[flatpak-user:org.gimp.GIMP.Nightly] creating override...'
+      flatpak override --user --filesystem=xdg-config/GIMP/3.0/themes/adw-gimp3:ro org.gimp.GIMP.Nightly && echo 'done.'
+    fi
+  fi
+
+elif command -v flatpak >/dev/null; then
+  echo '[system] no system GIMP installation found.'
+  echo '[flatpak] installing for flatpak GIMP installations...'
+  if [[ -d "$HOME/.var/app/org.gimp.GIMP" ]]; then
+    echo '[flatpak:org.gimp.GIMP] copying theme...'
+    mkdir -p ~/.var/app/org.gimp.GIMP/config/GIMP/3.0/themes/
+    cp -Rv adw-gimp3 ~/.var/app/org.gimp.GIMP/config/GIMP/3.0/themes/
+  fi
+  if [[ -d "$HOME/.var/app/org.gimp.GIMP.Nightly" ]]; then
+    echo '[flatpak:org.gimp.GIMP.Nightly] copying theme...'
+    mkdir -p ~/.var/app/org.gimp.GIMP.Nightly/config/GIMP/3.0/themes/
+    cp -Rv adw-gimp3 ~/.var/app/org.gimp.GIMP.Nightly/config/GIMP/3.0/themes/
+  fi
+fi
+
+echo '[flatpak] installing adw-gtk3 GTK3 theme for flatpaks...'
+if command -v flatpak >/dev/null; then
+  flatpak install --assume-yes --noninteractive org.gtk.Gtk3theme.adw-gtk3 org.gtk.Gtk3theme.adw-gtk3-dark
+fi


### PR DESCRIPTION
Configures flatpak overrides for GIMP apps to read the `adw-gimp3` theme config from the host environment.

Also installs the flatpak version of the `adw-gtk3` theme.

Closes #4
